### PR TITLE
fix(ci): pin npm to 11.15.0 so `npm stage publish` works

### DIFF
--- a/.github/workflows/npm-test-publish.yaml
+++ b/.github/workflows/npm-test-publish.yaml
@@ -45,6 +45,9 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org/
           package-manager-cache: false
+      # npm stage publish requires npm >= 11.15.0, newer than the npm bundled with Node 24.
+      # Remove this step once setup-node's default Node ships npm >= 11.15.0.
+      - run: npm install -g npm@11.15.0
       - run: npm ci
       - run: npm run build --if-present
       - run: npm stage publish


### PR DESCRIPTION
Fixes # (no related issue, small CI fix)

**Changes**
- Pin npm to 11.15.0 in the `publish-npm` job before `npm stage publish`, so staged publishing works on the npm bundled with Node 24 (11.13.0, below npm's 11.15.0 requirement). Without it the publish job fails on the next release.

@riyadhalnur Please look into this :smiley: